### PR TITLE
Add `service_name` and `service_environment` as indexed attribute by AWS cloudwatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traceroot"
-version = "0.0.3a1"
+version = "0.0.3a3"
 description = "A clean, principled wrapper around OpenTelemetry, AWS CloudWatch, and AWS X-Ray for enhanced debugging experience"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/traceroot/__init__.py
+++ b/traceroot/__init__.py
@@ -2,7 +2,7 @@ from traceroot.logger import get_logger
 from traceroot.tracer import _initialize_tracing as init
 from traceroot.tracer import trace
 
-__version__ = '0.0.3a1'
+__version__ = '0.0.3a3'
 
 init()
 

--- a/traceroot/tracer.py
+++ b/traceroot/tracer.py
@@ -188,6 +188,9 @@ def _trace(function: Callable, options: TraceOptions, *args: Any,
         return
 
     with _span as span:
+        # Set AWS X-Ray annotations as individual attributes
+        span.set_attribute("service_name", _config.service_name)
+        span.set_attribute("service_environment", _config.environment)
         # Add parameter attributes if requested
         if options.trace_params:
             parameter_values = _params_to_dict(


### PR DESCRIPTION
You need to use following yaml for the otel config
```yaml
exporters:
  awsxray:
    indexed_attributes:
      - service_name
      - service_environment
  debug:

processors:
  batch: {}

receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: 0.0.0.0:4318
        include_metadata: true

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [awsxray, debug]
```